### PR TITLE
fix: Add `run` function import to furnaces

### DIFF
--- a/src/js/machines/database/data/arc-furnace.js
+++ b/src/js/machines/database/data/arc-furnace.js
@@ -3,7 +3,7 @@ import { machineUpg } from "../init";
 
 import { GameDatabase } from "@/js/database/index";
 
-import { arr } from "@/utils/index";
+import { arr, run } from "@/utils/index";
 
 const metals = ["iron", "lead", "copper", "silver", "gold", "quicksilver"];
 

--- a/src/js/machines/database/data/furnace-basic.js
+++ b/src/js/machines/database/data/furnace-basic.js
@@ -3,7 +3,7 @@ import { machineUpg } from "../init";
 
 import { GameDatabase } from "@/js/database/index";
 
-import { arr } from "@/utils/index";
+import { arr, run } from "@/utils/index";
 
 const recipes = [{
 	input: { resource: "clay", amount: 0.2 },


### PR DESCRIPTION
When buying furnaces, it would break because the `run` function wasn't imported from the utils. 

(PS TypeScript would have caught this 😁)