### PR TITLE
Fix eventhub static dispatch arity

### DIFF
--- a/src/js/eventhub.js
+++ b/src/js/eventhub.js
@@ -29,9 +29,9 @@ window.EventHub = class EventHub {
 	}
 
 	// eslint-disable-next-line max-params
-	static dispatch(event, ...args) {
-		EventHub.logic.dispatch(event, ...args);
-		GameUI.dispatch(event, ...args);
+	static dispatch(event, args) {
+		EventHub.logic.dispatch(event, args);
+		GameUI.dispatch(event, args);
 	}
 };
 


### PR DESCRIPTION
This fixes that the instance method of EventHub has an arity of 2

```js
	dispatch(event, args) {
		const handlers = this._handlers[event];
		if (handlers === undefined) return;
		for (const handler of handlers) {
			handler.fn(args);
		}
	}
```

but the static version is incorrectly variadic:

```js
	// eslint-disable-next-line max-params
	static dispatch(event, ...args) {
		EventHub.logic.dispatch(event, ...args);
		GameUI.dispatch(event, ...args);
	}
```

As far as I can find, `dispatch` is only ever called with 0 or 1 arguments.