### PR TITLE
Quality Fix: moved expand collapse icon to 2nd spot

### DIFF
--- a/src/components/machines/MachineSidebar.vue
+++ b/src/components/machines/MachineSidebar.vue
@@ -62,6 +62,11 @@ function deleteMachine() {
 			@mousedown="emit('move-machine-start', $event)"
 		/>
 		<div
+			class="fas"
+			:class="machine.data.min ? 'fa-expand-arrows-alt' : 'fa-compress-arrows-alt'"
+			@mousedown="machine.toggleMinimized()"
+		/>
+		<div
 			v-if="machine.isUpgradeable"
 			class="fas fa-arrow-up"
 			:class="{
@@ -80,11 +85,6 @@ function deleteMachine() {
 			v-if="!machine.data.min"
 			class="fas fa-chart-bar"
 			@mousedown="machine.showProduction()"
-		/>
-		<div
-			class="fas"
-			:class="machine.data.min ? 'fa-expand-arrows-alt' : 'fa-compress-arrows-alt'"
-			@mousedown="machine.toggleMinimized()"
 		/>
 		<div
 			v-if="!machine.data.isDefault"


### PR DESCRIPTION
helps keep mouse in same spot and not get surprised with the upgrade or info modal if you prefer playing with collapsed blocks.